### PR TITLE
Add a ruler at 80 characters

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -7,6 +7,7 @@
     "[c]": {
         "editor.detectIndentation": false,
         "editor.tabSize": 8,
-        "editor.insertSpaces": false
+        "editor.insertSpaces": false,
+        "editor.rulers": [80]
     }
 }


### PR DESCRIPTION
Kernel folks insist on a maximum line length of 80 chars, so let's help
developers with a ruler.