### PR TITLE
Apply code style to headers files

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -9,5 +9,8 @@
         "editor.tabSize": 8,
         "editor.insertSpaces": false,
         "editor.rulers": [80]
+    },
+    "files.associations": {
+        "*.h": "c"
     }
 }


### PR DESCRIPTION
The tab size and other C style rules were not being applied to
.h/headers files.
Doing the file association between .h files and C language fixed it.