### PR TITLE
settings: Add another ruler at 100 characters

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -8,7 +8,7 @@
         "editor.detectIndentation": false,
         "editor.tabSize": 8,
         "editor.insertSpaces": false,
-        "editor.rulers": [80]
+        "editor.rulers": [80,100]
     },
     "files.associations": {
         "*.h": "c"


### PR DESCRIPTION
The 80-column codestyle was deprecated back in 2020 in favor of up-to 100 characters:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bdc48fa11e46