### PR TITLE
Fix newer kernels

### DIFF
--- a/generate_compdb.py
+++ b/generate_compdb.py
@@ -13,7 +13,7 @@ import re
 import sys
 
 
-CMD_VAR_RE = re.compile(r'^\s*cmd_(\S+)\s*:=\s*(.+)\s*$', re.MULTILINE)
+CMD_VAR_RE = re.compile(r'^\s*(?:saved)?cmd_(\S+)\s*:=\s*(.+)\s*$', re.MULTILINE)
 SOURCE_VAR_RE = re.compile(r'^\s*source_(\S+)\s*:=\s*(.+)\s*$', re.MULTILINE)
 
 


### PR DESCRIPTION
The first patch is a fix that was triggered by running the script in a newer kernel that triggers the issue. So, instead of having an exception, let's print a warning and return an empty list...

The second patch is then supporting newer kernels  fallbacking  to the old regex if running the script on a kernel < 6.3. Honestly I did not gave it much thought to the regex so maybe we could have one regex for matching both case but well, this is not that horrible :)